### PR TITLE
Add ID to "Why Kotlin?" section

### DIFF
--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -64,7 +64,7 @@
     <a id="try-kotlin"></a>
     {% include 'inc/pages/index/code-examples.html' %}
 
-    <section class="kto-overview-section kotlin-why-section">
+    <section id="why-kotlin" class="kto-overview-section kotlin-why-section">
         <div class="g-layout">
             <h2 class="kto-overview-section__title">Why Kotlin?</h2>
             <ul class="kto-features-list">


### PR DESCRIPTION
I was writing up an email suggesting the use of Kotlin over Java for a project.

The "Why Kotlin?" section of the site is an excellent showcase of the benefits of Kotlin, so it would be great to be able to link directly there.

Thanks for the amazing work you're all doing with Kotlin!